### PR TITLE
Hotfix for owncloud 8.1

### DIFF
--- a/components/nsOwncloud.js
+++ b/components/nsOwncloud.js
@@ -642,9 +642,9 @@ nsOwncloudFileUploader.prototype = {
           var response = JSON.parse(req.responseText);
           if (typeof response.ocs.data.url !== 'undefined') {
             this.owncloud._urlsForFiles[this.file.path] = response.ocs.data.url;
-            if(!this.owncloud._protectUploads.length) {
-              this.owncloud._urlsForFiles[this.file.path] += '&download';
-            }
+//            if(!this.owncloud._protectUploads.length) {
+//              this.owncloud._urlsForFiles[this.file.path] += '&download';
+//            }
             aCallback(this.requestObserver, Cr.NS_OK);
           } else {
             aCallback(this.requestObserver, Ci.nsIMsgCloudFileProvider.uploadErr);


### PR DESCRIPTION
Hello,
The suffix '&download' don't work for OC 8.1 .
The new format "https://<server>/index.php/s/<uid>&download" -> make wrong uri.
