### PR TITLE
Add an authentication header to _getShareUrl

### DIFF
--- a/components/nsOwncloud.js
+++ b/components/nsOwncloud.js
@@ -680,6 +680,7 @@ nsOwncloudFileUploader.prototype = {
     req.setRequestHeader('Content-Type', "application/x-www-form-urlencoded");
     req.setRequestHeader("Content-Length", formData.length);
     req.setRequestHeader('OCS-APIREQUEST', 'true');
+    req.setRequestHeader('Authorization', "Basic " + btoa(this.owncloud._userName + ":" + this.owncloud._password));
 
     req.onload = function() {
       this.log.debug("Raw response: " + req.responseText);


### PR DESCRIPTION
This authentication header seems to be necessary to create a share link in Nextcloud 11. Otherwise the files are uploaded correctly, but no share link is created. The plugin fails with kind of "general problem". With the authentication header, it works. We have found this solution by analyzing the Nextcloud logs in combination with trial and error. I can provide a Nextcloud 11 installation for test purposes if neeeded. 

My JavaScript knowledge is very limited -- maybe there is a nicer way to add the authentication header.